### PR TITLE
Return a file instance when calling #to_file

### DIFF
--- a/lib/vcardio/vcard.rb
+++ b/lib/vcardio/vcard.rb
@@ -45,7 +45,13 @@ module VCardio
     alias_method :to_s, :to_abnf
 
     def to_file(path)
-      File.write(path, to_abnf)
+      file = File.new(path, 'w')
+
+      file.write(to_abnf)
+      file.flush
+      file.close
+
+      file
     end
 
     def ==(other)

--- a/lib/vcardio/version.rb
+++ b/lib/vcardio/version.rb
@@ -1,3 +1,3 @@
 module VCardio
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/vcardio.gemspec
+++ b/vcardio.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
     end
   )
 
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.bindir                = 'exe'
+  spec.executables           = spec.files.grep(/^exe\//) { |f| File.basename(f) }
+  spec.require_paths         = ['lib']
+  spec.required_ruby_version = '>= 1.9.2'
 
   spec.add_dependency 'manilla', '~> 1.0.0'
 


### PR DESCRIPTION
Was returning amount of bytes written. Seems to be more useful when a file is returned.
